### PR TITLE
Modify 'for' loops performance sensitively

### DIFF
--- a/library/src/main/java/com/yqritc/recyclerviewmultipleviewtypesadapter/EnumMapBindAdapter.java
+++ b/library/src/main/java/com/yqritc/recyclerviewmultipleviewtypesadapter/EnumMapBindAdapter.java
@@ -34,7 +34,7 @@ public abstract class EnumMapBindAdapter<E extends Enum<E>> extends DataBindAdap
     @Override
     public int getPosition(DataBinder binder, int binderPosition) {
         E targetViewType = getEnumFromBinder(binder);
-        for (int i = 0; i < getItemCount(); i++) {
+        for (int i = 0, count = getItemCount(); i < count; i++) {
             if (targetViewType == getEnumFromPosition(i)) {
                 binderPosition--;
                 if (binderPosition < 0) {

--- a/library/src/main/java/com/yqritc/recyclerviewmultipleviewtypesadapter/ListBindAdapter.java
+++ b/library/src/main/java/com/yqritc/recyclerviewmultipleviewtypesadapter/ListBindAdapter.java
@@ -16,7 +16,8 @@ public class ListBindAdapter extends DataBindAdapter {
     @Override
     public int getItemCount() {
         int itemCount = 0;
-        for (DataBinder binder : mBinderList) {
+        for (int i = 0, size = mBinderList.size(); i < size; i++) {
+            DataBinder binder = mBinderList.get(i);
             itemCount += binder.getItemCount();
         }
         return itemCount;
@@ -25,7 +26,7 @@ public class ListBindAdapter extends DataBindAdapter {
     @Override
     public int getItemViewType(int position) {
         int itemCount = 0;
-        for (int viewType = 0; viewType < mBinderList.size(); viewType++) {
+        for (int viewType = 0, size = mBinderList.size(); viewType < size; viewType++) {
             itemCount += mBinderList.get(viewType).getItemCount();
             if (position < itemCount) {
                 return viewType;
@@ -57,7 +58,7 @@ public class ListBindAdapter extends DataBindAdapter {
     @Override
     public int getBinderPosition(int position) {
         int binderItemCount;
-        for (int i = 0; i < mBinderList.size(); i++) {
+        for (int i = 0, size = mBinderList.size(); i < size; i++) {
             binderItemCount = mBinderList.get(i).getItemCount();
             if (position - binderItemCount < 0) {
                 break;


### PR DESCRIPTION
Thank you very much for such an amazing library! I have made tiny modification here to make the library performance better just a tiny bit..
## Done

I have modified for loops inside `EnumMapBindAdapter` and `ListBindAdapter` to calculate initial list size only once. I have decided to make this modification after seeing this youtube video: https://www.youtube.com/watch?v=b6zKBZcg5fk&feature=youtu.be&t=1537
