### PR TITLE
Replacement of "compile" with "implementation"

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ repositories {
 }
 
 dependencies {
-    compile 'com.yqritc:recyclerview-multiple-viewtypes-adapter:1.1.0'
+    implementation 'com.yqritc:recyclerview-multiple-viewtypes-adapter:1.1.0'
 }
 ```
 


### PR DESCRIPTION
As "compile" is going to be deprecated end-2018, this PR replaces with "implementation" that is the new usage.